### PR TITLE
Development_Setup.rst: Increase readability

### DIFF
--- a/Developers/Development_Setup.rst
+++ b/Developers/Development_Setup.rst
@@ -28,6 +28,7 @@ repository. The former is the core of coala, and the latter contains the set
 of standard bears. You can fork and clone the repositories from:
 
 https://github.com/coala-analyzer/coala
+
 https://github.com/coala-analyzer/coala-bears
 
 Installing from Git


### PR DESCRIPTION
The link to the `coala-bears` and `coala` appears on the same line.
Hence, isn't really readable. This commit gives them both a different
line