### PR TITLE
Shell command: Remove redundant whitespace

### DIFF
--- a/Developers/Executing_Tests.rst
+++ b/Developers/Executing_Tests.rst
@@ -28,7 +28,7 @@ coala project directory.
 
 ::
 
-    $ pip3 install -r test-requirements.txt  -r requirements.txt
+    $ pip3 install -r test-requirements.txt -r requirements.txt
 
 You can then execute our tests with
 


### PR DESCRIPTION
Removed redundant whitespace in lime 31 before -r in shell command.
Fixes coala/documentation#103
