### PR TITLE
Git_Basics: Fix Rebase link in Git_Basics

### DIFF
--- a/Developers/Git_Basics.rst
+++ b/Developers/Git_Basics.rst
@@ -185,7 +185,7 @@ You are awesome!
     to sync your local fork with the remote repository before sending
     a pull request.
 
-    More information regarding syncing can be found `here <http://coala.readthedocs.org/en/latest/Users/Tutorials/Git_Help.html#keeping-your-fork-in-sync>`_.
+    More information regarding syncing can be found `here <http://coala.readthedocs.io/en/latest/Developers/Git_Basics.html#rebasing>`_.
 
 Follow-up
 ---------


### PR DESCRIPTION
Currently,a link in "Creating a Pull Request" section points
to dangling link in Git_Basics.rst.
This fix points document link to right location i.e., #rebasing
from same document.

Fixes : https://github.com/coala/documentation/issues/124

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>