### PR TITLE
Newcomers_Guide.rst: Fix broken link

### DIFF
--- a/Developers/Newcomers_Guide.rst
+++ b/Developers/Newcomers_Guide.rst
@@ -158,7 +158,7 @@ coala **clean** and **stable**.
 
 .. seealso::
 
-    `Review Process <http://coala.readthedocs.org/en/latest/Getting_Involved/Review.html>`_.
+    `Review Process <http://coala.readthedocs.io/en/latest/Developers/Review.html>`_.
 
 Now, if you need to modify your code, you can simply edit it again, add it and
 commit it using


### PR DESCRIPTION
In Newcomers_Guide.rst the link is changed to http://coala.readthedocs.io/en/latest/Developers/Review.html


Fixes https://github.com/coala/documentation/issues/128