### PR TITLE
Writing_Linter_Bears.rst : Links to the API doc

### DIFF
--- a/Developers/Writing_Linter_Bears.rst
+++ b/Developers/Writing_Linter_Bears.rst
@@ -387,5 +387,5 @@ Congratulations!
 Where to Find More...
 ---------------------
 
-If you need more information about the ``@linter`` decorator, refer to the API
-documentation.
+If you need more information about the ``@linter`` decorator, refer to the `API
+documentation. <http://docs.coala.io/en/stable/Users/Tutorials/Linter_Bears.html>`_


### PR DESCRIPTION
It links the footer note to the coala API documentation for more readings on linter decorator.

Fixes https://github.com/coala/documentation/issues/21