### PR TITLE
Writing_Linter_Bears.rst : Links to the linter bear tutorial

### DIFF
--- a/Developers/Git_Basics.rst
+++ b/Developers/Git_Basics.rst
@@ -149,7 +149,7 @@ parts. They should have a newline between them.
 .. seealso::
 
   For more information about writing commit messages, check this
-  `link <http://coala.readthedocs.org/en/latest/Getting_Involved/Writing_Good_Commits.html>`_.
+  `link <http://coala.io/commit>`_.
 
 Now that your message is written, you will have to save the file. Press escape
 to exit insert mode, and save the file (in Vim that is being done by pressing

--- a/Developers/Writing_Linter_Bears.rst
+++ b/Developers/Writing_Linter_Bears.rst
@@ -387,5 +387,4 @@ Congratulations!
 Where to Find More...
 ---------------------
 
-If you need more information about the ``@linter`` decorator, refer to the API
-documentation.
+If you need more information about the ``@linter`` decorator, refer to the `writing linter bears tutorial. <http://docs.coala.io/en/stable/Users/Tutorials/Linter_Bears.html>`_


### PR DESCRIPTION
It links the footer note to the writing linter bear tutorial for more readings on linter decorator.

Fixes https://github.com/coala/documentation/issues/21