### PR TITLE
Linter_Bears_Advanced: Fix typo

### DIFF
--- a/Developers/Linter_Bears_Advanced.rst
+++ b/Developers/Linter_Bears_Advanced.rst
@@ -34,7 +34,7 @@ The path of the temporary configuration file can be accessed inside
         @staticmethod
         def generate_config(filename, file):
             config_file = ("value1 = 1\n"
-                           "value=2 = 2")
+                           "value2 = 2")
             return config_file
 
         @staticmethod


### PR DESCRIPTION
Change the variable name value=2 to value2
Closes https://github.com/coala/documentation/issues/140