### PR TITLE
Executing_Tests.rst: Remove redundant whitespace

### DIFF
--- a/Developers/Executing_Tests.rst
+++ b/Developers/Executing_Tests.rst
@@ -28,7 +28,7 @@ coala project directory.
 
 ::
 
-    $ pip3 install -r test-requirements.txt  -r requirements.txt
+    $ pip3 install -r test-requirements.txt -r requirements.txt
 
 You can then execute our tests with
 


### PR DESCRIPTION
Removes extra whitespace in shell command (line 31) in coala/documentation
/Developers/Executing_Tests.rst
Closes #103