### PR TITLE
Use alabaster Theme

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,0 +1,11 @@
+/*
+ * custom.css
+ * ~~~~~~~~~
+ *
+ * Custom stylesheet
+ *
+ */
+
+div.sphinxsidebar .caption-text {
+    font-size: 120%;
+}

--- a/conf.py
+++ b/conf.py
@@ -110,12 +110,16 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
-
+html_theme = 'alabaster'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = {
+    'github_user': 'coala',
+    'github_repo': 'coala',
+    'github_banner': True,
+    'github_type': 'star'
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
@@ -139,7 +143,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ['_static/']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -155,7 +159,15 @@ html_static_path = []
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+html_sidebars = {
+    '**': [
+        'about.html',
+        'searchbox.html',
+        'navigation.html',
+        'relations.html',
+        'donate.html',
+    ]
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
Update conf.py to use alabaster theme. Customize the sidebar,
and add git repository information

Closes https://github.com/coala/documentation/issues/99


Hi, please check, and let me know what you think.

Do test it on your own environment first :) 
Thanks.

Here's how it looks like on my local env.
<img width="1127" alt="screen shot 2016-10-15 at 10 30 00 am" src="https://cloud.githubusercontent.com/assets/5844587/19412074/77153362-92c2-11e6-89e1-50f0a00e8a3a.png">
