### PR TITLE
Developers/Writing_Good_Commits.rst: Deleted Repeated "and"

### DIFF
--- a/Developers/Newcomers_Guide.rst
+++ b/Developers/Newcomers_Guide.rst
@@ -158,8 +158,7 @@ For more information about reviewing code, check out
 
 .. note::
 
-    Reviewing code helps you by watching other people's mistakes and not making
-    them yourself in the future!
+    Reviewing code helps you by watching other people's mistakes, you are improving yourself by doing this and not making them yourself in the future!
 
 Step 8. Review Process
 ----------------------

--- a/Developers/Writing_Good_Commits.rst
+++ b/Developers/Writing_Good_Commits.rst
@@ -51,7 +51,7 @@ Example:
 
 -  Maximum of 50 characters.
 -  Should describe the *change* - the action being done in the commit.
--  Should have a tag and and a short description separated by a colon (``:``)
+-  Should have a tag and a short description separated by a colon (``:``)
 
    -  **Tag**
 


### PR DESCRIPTION
Deleted repeated "and" from the following sentence
"Should have a tag and and a short description separated by a colon"
in Writing_Good_commits.rst

Fixes https://github.com/coala/documentation/issues/151