### PR TITLE
Mention coala docs url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,9 @@
 The official documentation for coala
 ====================================
 
-This is the official documentation for coala. The coala repository can be found
-`here <https://github.com/coala/coala>`__.
+This is the official documentation for coala, and it is online at https://docs.coala.io.
+The coala repository can be found
+`here <https://github.com/coala/coala>`__. 
 
 How to build
 ============


### PR DESCRIPTION
Closes #201 

Here is the change.
I think as maintainer you can also edit the description on directly on github eg

<img width="376" alt="screen shot 2016-10-17 at 7 33 10 pm" src="https://cloud.githubusercontent.com/assets/5844587/19462351/0e107d28-94a1-11e6-9f78-4b1ca6b68aa0.png">

You can then add the docs url and press save.
<img width="1007" alt="screen shot 2016-10-17 at 7 35 03 pm" src="https://cloud.githubusercontent.com/assets/5844587/19462335/f8fcc69e-94a0-11e6-9c81-4c2d7b3301e6.png">

I was able to do this in my forked repo see https://github.com/Mariatta/documentation

Thanks 😸 