### PR TITLE
Update Writing_Good_Commits.rst

### DIFF
--- a/Developers/Writing_Good_Commits.rst
+++ b/Developers/Writing_Good_Commits.rst
@@ -14,7 +14,7 @@ better.
 What Makes a Good Commit
 ------------------------
 
-A good commit is atomic. It should describe only one change and not more.
+A good commit is atomic. It should describe only one a single change.
 
 Why? Because we may create more bugs if we had more changes per commit.
 

--- a/Developers/Writing_Good_Commits.rst
+++ b/Developers/Writing_Good_Commits.rst
@@ -14,7 +14,7 @@ better.
 What Makes a Good Commit
 ------------------------
 
-A good commit is atomic. It should describe only one a single change.
+A good commit is atomic. It should describe only a single change.
 
 Why? Because we may create more bugs if we had more changes per commit.
 


### PR DESCRIPTION
Writing_Good_Commits.rst: Reword a line

The file consisted of a line saying "It should describe only one change and not more.". Changed it to "It should describe only a single change." to enhance its meaning.

Closes https://github.com/coala/documentation/issues/150
