### PR TITLE
Writing_Bears: Add ``.py`` to ``HelloWorldBear``

### DIFF
--- a/Developers/Writing_Bears.rst
+++ b/Developers/Writing_Bears.rst
@@ -60,7 +60,7 @@ each file:
                 file):
             self.debug("Hello World! Checking file", filename, ".")
 
-This bear is stored at ``./bears/HelloWorldBear``
+This bear is stored at ``./bears/HelloWorldBear.py``
 
 In order to let coala execute this bear you need to let coala know where
 to find it. We can do that with the ``-d`` (``--bear-dirs``) argument:


### PR DESCRIPTION
The bear is a python file and should have a ``.py`` extension.

Closes https://github.com/coala/documentation/issues/224