### PR TITLE
Add minimum required pip version to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@ You can test the documentation locally through simply running
 
     make html
 
-in the root directory. This generates _build\html\index.html that you can view
-on your browser.
+in the root directory. This generates ``_build/html/index.html`` that you can
+view on your browser.
 
 If you want to add new pages, you need to alter the index.rst file in the root
 directory. Please read

--- a/Users/Install.rst
+++ b/Users/Install.rst
@@ -24,6 +24,9 @@ also show you more information about your current pip version:
 
     $ pip show pip
 
+Make sure you have pip >= 8 installed as older versions might prevent coala
+from being installed properly.
+
 Installing coala
 ----------------
 


### PR DESCRIPTION
This PR  
1. adds better formatting for the mention of the output directory of the documentation
2. adds information about a minimum required pip version to prevent installation errors 

This is one of two steps to fix https://github.com/coala/documentation/issues/237 . Another PR will follow for the coala repository's README
