### PR TITLE
Fix hyperlink in Developers/Development_Setup.rst and Users/Tutorials.rst #247

### DIFF
--- a/Developers/Development_Setup.rst
+++ b/Developers/Development_Setup.rst
@@ -13,7 +13,7 @@ We highly recommend installing coala in a virtualenv for development. This
 will allow you to have a contained environment in which to modify coala,
 separate from any other installation of coala that you may not want to
 break. For more information about virtualenvs, please refer to the
-:ref:`virtualenv setup <venv-setup>` section for information on setting one
+`virtualenv setup <https://docs.coala.io/en/latest/Help/MAC_Hints.html#create-virtual-environments-with-pyvenv>`__ section for information on setting one
 up.
 
 Repositories

--- a/Users/Tutorial.rst
+++ b/Users/Tutorial.rst
@@ -14,8 +14,8 @@ recommended.)
 .. note::
 
     Here's a list of our
-    'supported languages
-    <https://github.com/coala/bear-docs/blob/master/README.rst>`.
+    `supported languages
+    <https://github.com/coala/bear-docs/blob/master/README.rst>`__.
 
 
 Get Some Code


### PR DESCRIPTION
Hyperlink "virtualenv setup" in Developers/Development_Setup.rst refer to MAC Hints virtual environment setup and "supported languages" in Users/Tutorials.rst refer to supported languages doc page on github.