### PR TITLE
Highlight current page in the navigation menu

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -13,3 +13,7 @@ div.sphinxsidebar .caption-text {
 img.logo {
     width: 100px;
 }
+
+.sphinxsidebarwrapper a.current.reference.internal {
+    font-weight: bold;
+}


### PR DESCRIPTION
Make the link to  the current page bold to distinguish it from inactive pages.

Let me know if this works.

<img width="983" alt="screen shot 2016-11-07 at 8 02 01 pm" src="https://cloud.githubusercontent.com/assets/5844587/20086492/99a947cc-a525-11e6-8dc2-5a153b9cccdd.png">


Closes #262