### PR TITLE
Resize the width of the logo

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -11,7 +11,7 @@ div.sphinxsidebar .caption-text {
 }
 
 img.logo {
-    width: 100px;
+    width: 100%;
 }
 
 .sphinxsidebarwrapper a.current.reference.internal {


### PR DESCRIPTION
Make the logo fill entire nav column.

<img width="1004" alt="screen shot 2016-11-09 at 9 11 43 pm" src="https://cloud.githubusercontent.com/assets/5844587/20165350/41421c88-a6c1-11e6-9583-d9ba08449266.png">

Hope this works :)
Thanks.

Closes #216