### PR TITLE
Developers/Writing_Good_Commits: Add body length

### DIFF
--- a/Developers/Writing_Good_Commits.rst
+++ b/Developers/Writing_Good_Commits.rst
@@ -21,7 +21,7 @@ Example of a good commit:
    maximum of 50 characters.
 
 - `This entrypoint.. ..for this`: Describe the reasoning of your changes
-   in maximum of 72 characters.
+   in maximum of 72 characters per line.
 
 - `Fixes https://github.com/coala/coala/issues/5861`: Mention the URL
    of the issue it closes or fixes.


### PR DESCRIPTION
Specify 'each line' for the length of commit body character limit

Closes https://github.com/coala/documentation/issues/308