### PR TITLE
Closes https://github.com/coala/documentation/issues/371

### DIFF
--- a/Users/Glob_Patterns.rst
+++ b/Users/Glob_Patterns.rst
@@ -197,7 +197,7 @@ brackets. Parentheses that have no match are ignored as well as
     >>> fnmatch("ac", "a?c")
     False
 
-``\*``
+``*``
 ~~~~~~
 
     Matches everything but the directory separator.
@@ -216,7 +216,7 @@ brackets. Parentheses that have no match are ignored as well as
     >>> fnmatch("ac", "a*c")
     True
 
-``\*\*``
+``**``
 ~~~~~~~~
 
     Matches everything.


### PR DESCRIPTION
Glob_Patterns: Got rid of extra escapes

Closes https://github.com/coala/documentation/issues/371