### PR TITLE
Docker_Image.rst: Add configuration for Circle CI

### DIFF
--- a/Users/Docker_Image.rst
+++ b/Users/Docker_Image.rst
@@ -69,3 +69,25 @@ on your code with a ``.travis.yml``, like this:
 
   For more information about Travis CI configuration, consult the
   `official documentation <https://docs.travis-ci.com/>`__.
+
+
+coala on Circle CI
+------------------
+
+You can use the ``coala/base`` docker image to perform static code analysis
+on your code with a ``circle.yml``, like this:
+
+::
+
+    machine:
+      services:
+        - docker
+
+    test:
+      override:
+        - docker run -v=$(pwd):/app --workdir=/app coala/base coala --ci
+
+.. note::
+
+  For more information about Circle CI configuration, consult the
+  `official documentation <https://circleci.com/docs/>`__.


### PR DESCRIPTION
Add configuration information for Circle CI on use
of the `coala/base` docker image.

Closes #379