### PR TITLE
Tutorial.rst: Update Show bears' Information

### DIFF
--- a/Users/Tutorial.rst
+++ b/Users/Tutorial.rst
@@ -376,19 +376,54 @@ Show bears' Information
 -----------------------
 
 To get help on using a bear or to get a description of the bear, use the
-``--show-description`` argument:
+``--show-details`` argument:
 
 ::
 
-    coala --bears=SpaceConsistencyBear --show-bears --show-description
+    coala --show-bears --show-details
 
-This will display a large amount of information regarding the bears that
-have been specified (in the ``.coafile`` or in the CLI arguments). It
-shows:
+This will display a large amount of information regarding the bears in
+the coala-bears directory. It shows:
 
 -  A description of what the bear does
--  The sections which use it
+-  The languages it analyses
 -  The settings it uses (optional and required)
+-  The categories it can detect and fix
+-  Absolute file path of the bear
+
+Example:
+::
+
+  SpaceConsistencyBear
+
+  Check and correct spacing for all textual data. This includes usage
+  of tabs vs. spaces, trailing whitespace and (missing) newlines
+  before the end of the file.
+
+  Supported languages:
+   * All
+
+  Needed Settings:
+   * use_spaces: True if spaces are to be used instead of tabs.
+
+  Optional Settings:
+   * allow_trailing_whitespace: Whether to allow trailing
+      whitespace or not. (Optional, defaults to 'False'.)
+   * indent_size: Number of spaces per indentation level.
+      (Optional, defaults to '4'.)
+   * enforce_newline_at_EOF: Whether to enforce a newline at
+      the End Of File. (Optional, defaults to 'True'.)
+   * tab_width: Number of spaces per indentation level.
+      (Optional, defaults to '4'.)
+
+  Can detect:
+   * Formatting
+
+  Can fix:
+   * Formatting
+
+  Path:
+   '/home/some_user/coala-bears/bears/general/SpaceConsistencyBear.py'
 
 Continuing the Journey
 ----------------------


### PR DESCRIPTION
'--show-description' does not display a large amount
of information regarding the bears that have been
specified (in the .coafile or in the CLI arguments),
since it shows bear descriptions for '--show-bears'.
This has been replaced by '--show-details'.

Closes https://github.com/coala/documentation/issues/397