### PR TITLE
Shell_Autocompletion.rst: Drop `which coala`

### DIFF
--- a/Users/Shell_Autocompletion.rst
+++ b/Users/Shell_Autocompletion.rst
@@ -18,7 +18,7 @@ If you're using ``bash``, add the following to your ``.bashrc``:
 
 ::
 
-    eval "$(register-python-argcomplete `which coala`)"
+    eval "$(register-python-argcomplete coala)"
 
 If you're using ``zsh``, add the following to your ``.zshrc``:
 
@@ -26,7 +26,4 @@ If you're using ``zsh``, add the following to your ``.zshrc``:
 
     autoload bashcompinit
     bashcompinit
-    eval "$(register-python-argcomplete `which coala`)"
-
-If you're seeing issues about ```which coala``` not being able to find
-``coala``, you could replace it with the path to your ``coala`` executable.
+    eval "$(register-python-argcomplete coala)"


### PR DESCRIPTION
The `argcomplete` package expects a script name, not a path (neither
relative, not absolute). Using `which coala` returns a path. Instead,
use just `coala` to register with `register-python-argcomplete`.

Related `argcomplete` documentation:
https://argcomplete.readthedocs.io/en/latest/#synopsis

Related discussion with `argcomplete` devs
https://github.com/kislyuk/argcomplete/issues/212

Fixes https://github.com/coala/documentation/issues/388

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
