### PR TITLE
Docker_image.rst: remove pip install instruction

### DIFF
--- a/Users/Docker_Image.rst
+++ b/Users/Docker_Image.rst
@@ -73,7 +73,6 @@ on your code with a ``.gitlab-ci.yml``, like this:
     check_code:
       image: coala/base
       script:
-      - pip install -r requirements.txt
       - coala --ci
 
 .. note::


### PR DESCRIPTION
Docker_image.rst: remove pip install instruction

http://docs.coala.io/en/latest/Users/Docker_Image.html#coala-on-gitlab-ci mentions invoking`pip install -r requirements.txt`. It is unnecessary and the documentation has been updated to show the changes.

Closes https://github.com/coala/documentation/issues/486