### PR TITLE
Docker_image.rst: remove pip install instruction

### DIFF
--- a/Users/Docker_Image.rst
+++ b/Users/Docker_Image.rst
@@ -73,7 +73,6 @@ on your code with a ``.gitlab-ci.yml``, like this:
     check_code:
       image: coala/base
       script:
-      - pip install -r requirements.txt
       - coala --ci
 
 .. note::


### PR DESCRIPTION
Docker_image.rst: remove pip install instruction

`pip install` is unnecessary in Docker image docs.

Closes https://github.com/coala/documentation/issues/486

