### PR TITLE
Correct grammatical error: an user --> a user

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -57,7 +57,7 @@ your code, regardless of the programming languages you use.**
 
 With coala, users can create
 :doc:`rules and standards <Users/coafile>` to be followed in the source
-code. coala has an **user-friendly interface** that is completely customizable.
+code. coala has a **user-friendly interface** that is completely customizable.
 It can be used in any environment and is completely modular.
 
 coala has a set of official bears (plugins) for several languages, including


### PR DESCRIPTION
index.rst: Correct grammatical error

This corrects the typo and changes it from an user --> a user.

Closes https://github.com/coala/documentation/issues/516