### PR TITLE
Update pre-commit hook example

### DIFF
--- a/Users/coala_as_Git_Hook.rst
+++ b/Users/coala_as_Git_Hook.rst
@@ -17,9 +17,9 @@ repository and add the lines:
 
 .. code:: bash
 
-    $ #!/bin/sh
-    $ set -e
-    $ coala
+    #!/bin/sh
+    set -e
+    coala
 
 You can also specify arguments like ``-S autoapply=false`` which tells
 coala to not apply any patch by itself. Or you can run specific sections with


### PR DESCRIPTION
Remove the $ sign from the beginning of each line in the .git/hooks/pre-commit file example.

Fixes https://github.com/coala/documentation/issues/538